### PR TITLE
Add stemming to lexer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-stemmers"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,6 +128,7 @@ dependencies = [
 name = "seroost"
 version = "0.1.0"
 dependencies = [
+ "rust-stemmers",
  "serde",
  "serde_json",
  "sqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+rust-stemmers = "1.2.0"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.91"
 sqlite = "0.30.3"

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,10 +1,13 @@
+use rust_stemmers::{Stemmer, Algorithm};
+
 pub struct Lexer<'a> {
     content: &'a [char],
+    stemmer: Stemmer,
 }
 
 impl<'a> Lexer<'a> {
     pub fn new(content: &'a [char]) -> Self {
-        Self { content }
+        Self { content, stemmer: Stemmer::create(Algorithm::English) }
     }
 
     fn trim_left(&mut self) {
@@ -38,7 +41,8 @@ impl<'a> Lexer<'a> {
         }
 
         if self.content[0].is_alphabetic() {
-            return Some(self.chop_while(|x| x.is_alphanumeric()).iter().map(|x| x.to_ascii_uppercase()).collect());
+            let word = self.chop_while(|x| x.is_alphanumeric()).iter().collect::<String>();
+            return Some(self.stemmer.stem(&word).to_ascii_uppercase());
         }
 
         return Some(self.chop(1).iter().collect());

--- a/src/main.rs
+++ b/src/main.rs
@@ -254,4 +254,3 @@ fn main() -> ExitCode {
 // TODO: search result must consist of clickable links
 // TODO: `index` while `serve`-ing together
 // TODO: parse pdf files
-// TODO: stemming


### PR DESCRIPTION
This pull adds stemming to lexer, adding `rust-stemmers`(rust implementation of [snowball stemmer](https://snowballstem.org/), no additional dependency) as dependency.

It also results in a bit slower performance:
(on AMD Ryzen 7 5800H, `./target/release/seroost index docs.gl`, used `hyperfine`):
```
release, stemmer:
  Time (mean ± σ):      1.341 s ±  0.018 s    [User: 1.321 s, System: 0.019 s]
  Range (min … max):    1.321 s …  1.373 s    10 runs
release, no stemmer:
  Time (mean ± σ):      1.187 s ±  0.027 s    [User: 1.167 s, System: 0.019 s]
  Range (min … max):    1.158 s …  1.248 s    10 runs

debug, stemmer:
  Time (mean ± σ):      8.798 s ±  0.091 s    [User: 8.763 s, System: 0.028 s]
  Range (min … max):    8.651 s …  8.873 s    5 runs
debug, no stemmer:
  Time (mean ± σ):      7.424 s ±  0.118 s    [User: 7.396 s, System: 0.020 s]
  Range (min … max):    7.267 s …  7.553 s    5 runs
```
