### PR TITLE
feat(ui): show results as you type

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-// TODO: live update results as you type
 async function search(prompt) {
     const results = document.getElementById("results")
     results.innerHTML = "";
@@ -20,8 +19,6 @@ async function search(prompt) {
 let query = document.getElementById("query");
 let currentSearch = Promise.resolve()
 
-query.addEventListener("keypress", (e) => {
-    if (e.key == "Enter") {
-        currentSearch.then(() => search(query.value));
-    }
+query.addEventListener("input", (e) => {
+    currentSearch.then(() => search(e.target.value));
 })


### PR DESCRIPTION
Changes event listener from [keypress](https://developer.mozilla.org/en-US/docs/Web/API/Element/keypress_event) to [input](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event), as it is deprecated and `keypress` doesn't get triggered when one presses backspace.