### PR TITLE
Save a call to `reverse`

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -52,8 +52,11 @@ impl Model {
                 result.push((path.clone(), rank));
             }
         }
-        result.sort_by(|(_, rank1), (_, rank2)| rank1.partial_cmp(rank2).expect(&format!("{rank1} and {rank2} are not comparable")));
-        result.reverse();
+        result.sort_by(|(_, rank1), (_, rank2)| {
+            rank2
+                .partial_cmp(rank1)
+                .expect(&format!("{rank1} and {rank2} are comparable"))
+        });
         result
     }
 


### PR DESCRIPTION
By flipping the comparison operation inside the closure, `.reverse()` can be avoided.