### PR TITLE
replace `partial_cmp` with `total_cmp` and use unstable sort for faster sorting

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -52,8 +52,7 @@ impl Model {
                 result.push((path.clone(), rank));
             }
         }
-        result.sort_by(|(_, rank1), (_, rank2)| rank1.partial_cmp(rank2).expect(&format!("{rank1} and {rank2} are not comparable")));
-        result.reverse();
+        result.sort_unstable_by(|(_, rank1), (_, rank2)| rank2.total_cmp(rank1));
         result
     }
 


### PR DESCRIPTION
This commit has three changes:
1. use `total_cmp` instead of `partial_cmp` to compare floats. Unlike `patial_cmp`, `total_cmp` doesn't return an error.
2. replace `Vec::sort_by()` with `Vec::sort_unstable_by()` to increase sorting speed.
3. avoid calling `Vec::reverse()` after sorting by comparing rank2 to rank1 instead of rank1 to rank2.